### PR TITLE
Correction documentation

### DIFF
--- a/_tools.mixins.scss
+++ b/_tools.mixins.scss
@@ -13,7 +13,7 @@
 // single value, e.g.:
 //
 // .foo {
-//     @include font-size(10px);
+//     @include inuit-font-size(10px);
 // }
 //
 @mixin inuit-font-size($inuit-font-size, $inuit-line-height: true) {


### PR DESCRIPTION
Documentation use old mixin name.

If user want to use small mixin name `@include font-size(10px);` they need to add it to there `_tools.aliases.scss` file ;)
